### PR TITLE
refactor(library): rename flutter_azure_tts to azure_tts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# flutter_azure_tts
+# azure_tts
 
 Flutter implementation of [Microsoft Azure Cognitive Text-To-Speech API](https://azure.microsoft.com/en-us/services/cognitive-services/text-to-speech/#features).
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_azure_tts/flutter_azure_tts.dart';
-import 'package:flutter_azure_tts/src/audio/audio_output_format.dart';
-import 'package:flutter_azure_tts/src/tts/tts_params.dart';
+import 'package:azure_tts/azure_tts.dart';
+import 'package:azure_tts/src/audio/audio_output_format.dart';
+import 'package:azure_tts/src/tts/tts_params.dart';
 
 void main() async {
   try {

--- a/lib/azure_tts.dart
+++ b/lib/azure_tts.dart
@@ -1,15 +1,15 @@
-library flutter_azure_tts;
+library azure_tts;
 
-import 'package:flutter_azure_tts/src/audio/audio_responses.dart';
-import 'package:flutter_azure_tts/src/tts/tts.dart';
-import 'package:flutter_azure_tts/src/tts/tts_params.dart';
-import 'package:flutter_azure_tts/src/voices/voices.dart';
+import 'package:azure_tts/src/audio/audio_responses.dart';
+import 'package:azure_tts/src/tts/tts.dart';
+import 'package:azure_tts/src/tts/tts_params.dart';
+import 'package:azure_tts/src/voices/voices.dart';
 
 export '/src/audio/audio.dart';
 export '/src/auth/auth.dart';
-export '/src/voices/voices.dart';
 export '/src/common/common.dart';
 export "/src/tts/tts_params.dart";
+export '/src/voices/voices.dart';
 
 class AzureTts {
   ///Initialises the framework.

--- a/lib/src/audio/audio_client.dart
+++ b/lib/src/audio/audio_client.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_azure_tts/src/audio/audio_type_header.dart';
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/base_client.dart';
+import 'package:azure_tts/src/audio/audio_type_header.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/base_client.dart';
 import 'package:http/http.dart' as http;
 
 class AudioClient extends BaseClient {

--- a/lib/src/audio/audio_handler.dart
+++ b/lib/src/audio/audio_handler.dart
@@ -1,11 +1,11 @@
-import 'package:flutter_azure_tts/src/audio/audio_client.dart';
-import 'package:flutter_azure_tts/src/audio/audio_request_param.dart';
-import 'package:flutter_azure_tts/src/audio/audio_response_mapper.dart';
-import 'package:flutter_azure_tts/src/audio/audio_responses.dart';
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/config.dart';
-import 'package:flutter_azure_tts/src/common/constants.dart';
-import 'package:flutter_azure_tts/src/ssml/ssml.dart';
+import 'package:azure_tts/src/audio/audio_client.dart';
+import 'package:azure_tts/src/audio/audio_request_param.dart';
+import 'package:azure_tts/src/audio/audio_response_mapper.dart';
+import 'package:azure_tts/src/audio/audio_responses.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/common/constants.dart';
+import 'package:azure_tts/src/ssml/ssml.dart';
 import 'package:http/http.dart' as http;
 
 import 'audio_type_header.dart';

--- a/lib/src/audio/audio_request_param.dart
+++ b/lib/src/audio/audio_request_param.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/voices/voices.dart';
+import 'package:azure_tts/src/voices/voices.dart';
 
 class AudioRequestParams {
   final Voice voice;

--- a/lib/src/audio/audio_response_mapper.dart
+++ b/lib/src/audio/audio_response_mapper.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_azure_tts/src/audio/audio_responses.dart';
-import 'package:flutter_azure_tts/src/common/base_response.dart';
-import 'package:flutter_azure_tts/src/common/base_response_mapper.dart';
+import 'package:azure_tts/src/audio/audio_responses.dart';
+import 'package:azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response_mapper.dart';
 import 'package:http/http.dart' as http;
 
 class AudioResponseMapper extends BaseResponseMapper {

--- a/lib/src/audio/audio_responses.dart
+++ b/lib/src/audio/audio_responses.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:flutter_azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response.dart';
 
 abstract class AudioResponse extends BaseResponse {
   AudioResponse({required int code, required String reason})

--- a/lib/src/audio/audio_type_header.dart
+++ b/lib/src/audio/audio_type_header.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_header.dart';
+import 'package:azure_tts/src/common/base_header.dart';
 
 class AudioTypeHeader extends BaseHeader {
   ///Audio format should be selected from [AudioOutputFormat] class.

--- a/lib/src/auth/auth_client.dart
+++ b/lib/src/auth/auth_client.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart';
 

--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:flutter_azure_tts/flutter_azure_tts.dart';
-import 'package:flutter_azure_tts/src/auth/auth_client.dart';
-import 'package:flutter_azure_tts/src/auth/auth_response_mapper.dart';
-import 'package:flutter_azure_tts/src/common/constants.dart';
+import 'package:azure_tts/azure_tts.dart';
+import 'package:azure_tts/src/auth/auth_client.dart';
+import 'package:azure_tts/src/auth/auth_response_mapper.dart';
+import 'package:azure_tts/src/common/constants.dart';
 
 ///Handles authorisation token requests
 class AuthHandler {

--- a/lib/src/auth/auth_response_mapper.dart
+++ b/lib/src/auth/auth_response_mapper.dart
@@ -1,6 +1,6 @@
-import 'package:flutter_azure_tts/src/auth/auth.dart';
-import 'package:flutter_azure_tts/src/common/base_response.dart';
-import 'package:flutter_azure_tts/src/common/base_response_mapper.dart';
+import 'package:azure_tts/src/auth/auth.dart';
+import 'package:azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response_mapper.dart';
 import 'package:http/http.dart' as http;
 
 class AuthResponseMapper extends BaseResponseMapper {

--- a/lib/src/auth/auth_responses.dart
+++ b/lib/src/auth/auth_responses.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response.dart';
 
 ///Represents the response object of a token request.
 ///Must be implemented by all the response cases objects.

--- a/lib/src/auth/authentication.dart
+++ b/lib/src/auth/authentication.dart
@@ -1,9 +1,8 @@
-import 'package:flutter_azure_tts/src/auth/auth_client.dart';
-import 'package:flutter_azure_tts/src/auth/auth_responses.dart';
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/config.dart';
-import 'package:flutter_azure_tts/src/common/constants.dart';
-
+import 'package:azure_tts/src/auth/auth_client.dart';
+import 'package:azure_tts/src/auth/auth_responses.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/common/constants.dart';
 import 'package:http/http.dart' as http;
 
 class Authentication {

--- a/lib/src/auth/authentication_types.dart
+++ b/lib/src/auth/authentication_types.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_header.dart';
+import 'package:azure_tts/src/common/base_header.dart';
 
 ///Base class that all authentications types must implement.
 abstract class AuthenticationTypeHeader extends BaseHeader {

--- a/lib/src/common/azure_exception.dart
+++ b/lib/src/common/azure_exception.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response.dart';
 
 class AzureException implements Exception {
   AzureException({required this.response});

--- a/lib/src/common/base_client.dart
+++ b/lib/src/common/base_client.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_header.dart';
+import 'package:azure_tts/src/common/base_header.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart';
 

--- a/lib/src/common/base_response_mapper.dart
+++ b/lib/src/common/base_response_mapper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response.dart';
 import 'package:http/http.dart' as http;
 
 abstract class BaseResponseMapper {

--- a/lib/src/common/common.dart
+++ b/lib/src/common/common.dart
@@ -1,1 +1,1 @@
-export 'package:flutter_azure_tts/src/common/azure_exception.dart';
+export 'package:azure_tts/src/common/azure_exception.dart';

--- a/lib/src/common/config.dart
+++ b/lib/src/common/config.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/auth/auth_token.dart';
+import 'package:azure_tts/src/auth/auth_token.dart';
 
 ///Holds all configurations
 class Config {

--- a/lib/src/common/constants.dart
+++ b/lib/src/common/constants.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/common/config.dart';
 
 class Endpoints {
   Endpoints._();

--- a/lib/src/common/respository.dart
+++ b/lib/src/common/respository.dart
@@ -1,15 +1,15 @@
 import 'dart:async';
 
-import 'package:flutter_azure_tts/src/audio/audio.dart';
-import 'package:flutter_azure_tts/src/audio/audio_handler.dart';
-import 'package:flutter_azure_tts/src/auth/auth.dart';
-import 'package:flutter_azure_tts/src/auth/auth_handler.dart';
-import 'package:flutter_azure_tts/src/auth/auth_token.dart';
-import 'package:flutter_azure_tts/src/common/azure_exception.dart';
-import 'package:flutter_azure_tts/src/common/config.dart';
-import 'package:flutter_azure_tts/src/tts/tts_params.dart';
-import 'package:flutter_azure_tts/src/voices/voices.dart';
-import 'package:flutter_azure_tts/src/voices/voices_handler.dart';
+import 'package:azure_tts/src/audio/audio.dart';
+import 'package:azure_tts/src/audio/audio_handler.dart';
+import 'package:azure_tts/src/auth/auth.dart';
+import 'package:azure_tts/src/auth/auth_handler.dart';
+import 'package:azure_tts/src/auth/auth_token.dart';
+import 'package:azure_tts/src/common/azure_exception.dart';
+import 'package:azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/tts/tts_params.dart';
+import 'package:azure_tts/src/voices/voices.dart';
+import 'package:azure_tts/src/voices/voices_handler.dart';
 
 ///Implements repository pattern to acces Azure resources
 class Repository {

--- a/lib/src/ssml/ssml.dart
+++ b/lib/src/ssml/ssml.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_azure_tts/src/voices/voice_model.dart';
+import 'package:azure_tts/src/voices/voice_model.dart';
 
 class Ssml {
   Ssml({required this.voice, required this.text, required this.speed});

--- a/lib/src/tts/tts.dart
+++ b/lib/src/tts/tts.dart
@@ -1,14 +1,14 @@
+import 'package:azure_tts/azure_tts.dart';
+import 'package:azure_tts/src/audio/audio_handler.dart';
+import 'package:azure_tts/src/auth/auth_client.dart';
+import 'package:azure_tts/src/auth/auth_handler.dart';
+import 'package:azure_tts/src/auth/auth_response_mapper.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/common/respository.dart';
+import 'package:azure_tts/src/utils/log.dart';
+import 'package:azure_tts/src/voices/voices_handler.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter_azure_tts/flutter_azure_tts.dart';
-import 'package:flutter_azure_tts/src/audio/audio_handler.dart';
-import 'package:flutter_azure_tts/src/auth/auth_client.dart';
-import 'package:flutter_azure_tts/src/auth/auth_handler.dart';
-import 'package:flutter_azure_tts/src/auth/auth_response_mapper.dart';
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/config.dart';
-import 'package:flutter_azure_tts/src/common/respository.dart';
-import 'package:flutter_azure_tts/src/utils/log.dart';
-import 'package:flutter_azure_tts/src/voices/voices_handler.dart';
 import 'package:http/http.dart' as http;
 
 ///Helper class for Azure Cognitive TTS requests

--- a/lib/src/tts/tts_params.dart
+++ b/lib/src/tts/tts_params.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_azure_tts/src/audio/audio_request_param.dart';
-import 'package:flutter_azure_tts/src/voices/voices.dart';
+import 'package:azure_tts/src/audio/audio_request_param.dart';
+import 'package:azure_tts/src/voices/voices.dart';
 
 class TtsParams extends AudioRequestParams {
   /// Rate is the speed at which the voice will speak.

--- a/lib/src/utils/log.dart
+++ b/lib/src/utils/log.dart
@@ -6,7 +6,7 @@ class Log {
   static void disable() => _enabled = false;
 
   static bool get isEnabled => _enabled;
-  static String package = "[flutter_azure_tts]";
+  static String package = "[azure_tts]";
 
   static void d(String message, [String? tag]) {
     if (isEnabled) print("$package -> ${tag ?? ""} : $message");

--- a/lib/src/voices/voices_client.dart
+++ b/lib/src/voices/voices_client.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/base_client.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/base_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart';
 

--- a/lib/src/voices/voices_handler.dart
+++ b/lib/src/voices/voices_handler.dart
@@ -1,9 +1,9 @@
-import 'package:flutter_azure_tts/src/auth/authentication_types.dart';
-import 'package:flutter_azure_tts/src/common/config.dart';
-import 'package:flutter_azure_tts/src/common/constants.dart';
-import 'package:flutter_azure_tts/src/voices/voices.dart';
-import 'package:flutter_azure_tts/src/voices/voices_client.dart';
-import 'package:flutter_azure_tts/src/voices/voices_response_mapper.dart';
+import 'package:azure_tts/src/auth/authentication_types.dart';
+import 'package:azure_tts/src/common/config.dart';
+import 'package:azure_tts/src/common/constants.dart';
+import 'package:azure_tts/src/voices/voices.dart';
+import 'package:azure_tts/src/voices/voices_client.dart';
+import 'package:azure_tts/src/voices/voices_response_mapper.dart';
 import 'package:http/http.dart' as http;
 
 class VoicesHandler {

--- a/lib/src/voices/voices_response_mapper.dart
+++ b/lib/src/voices/voices_response_mapper.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:flutter_azure_tts/flutter_azure_tts.dart';
-import 'package:flutter_azure_tts/src/common/base_response.dart';
-import 'package:flutter_azure_tts/src/common/base_response_mapper.dart';
+import 'package:azure_tts/azure_tts.dart';
+import 'package:azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/common/base_response_mapper.dart';
 import 'package:http/http.dart' as http;
 
 class VoicesResponseMapper extends BaseResponseMapper {

--- a/lib/src/voices/voices_responses.dart
+++ b/lib/src/voices/voices_responses.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_azure_tts/src/common/base_response.dart';
-import 'package:flutter_azure_tts/src/voices/voice_model.dart';
+import 'package:azure_tts/src/common/base_response.dart';
+import 'package:azure_tts/src/voices/voice_model.dart';
 
 class VoicesResponse extends BaseResponse {
   VoicesResponse({required int code, required String reason})

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
-name: flutter_azure_tts
+name: azure_tts
 description: Flutter implementation of Microsoft Azure Cognitive Text-To-Speech
-version: 0.1.6
-homepage: https://github.com/ghuyfel/flutter_azure_tts
+version: 0.0.1
+homepage: https://github.com/willianveit/flutter_azure_tts/packages
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
Renamed the library from `flutter_azure_tts` to `azure_tts` across all files to simplify naming and improve clarity. This involved updating package imports, changing the README title, and modifying the package name in `pubspec.yaml`.

The version in `pubspec.yaml` was reset to `0.0.1`, reflecting this significant name change.